### PR TITLE
Fixed handling of escaped quotation marks

### DIFF
--- a/src/dm_logger.vala
+++ b/src/dm_logger.vala
@@ -221,9 +221,12 @@ namespace DMLogger
       parameters = { filename, git_version };
     }
 
-    public string parse_message( string? message, string[] params )
+    public string parse_message( string? _message, string[] params )
     {
       StringBuilder new_message = new StringBuilder( );
+
+      /* Unescape \n, \", etc. characters */
+      string message = _message.compress( );
 
       for ( int i = 0; i < message.char_count(); i++ )
       {
@@ -476,6 +479,9 @@ namespace DMLogger
         message = (!)mdb_message;
       }
     }
+
+    /* Unescape \n, \", etc. characters */
+    message = message.compress( );
 
     /* Replace the ${...} patterns using the given list of arguments. */
     va_list l = va_list( );

--- a/src/dm_logger.vala
+++ b/src/dm_logger.vala
@@ -221,7 +221,13 @@ namespace DMLogger
       parameters = { filename, git_version };
     }
 
-    public string parse_message( string? _message, string[] params )
+    /**
+     * Parses the given message and inserts the given parameters into it.
+     * @param _message The message to be parsed.
+     * @param params The parameters to be inserted into the message.
+     * @return The parsed message containing the given parameters.
+     */
+    public string parse_message( string _message, string[] params )
     {
       StringBuilder new_message = new StringBuilder( );
 
@@ -332,7 +338,7 @@ namespace DMLogger
             else
             {
               stdout.printf( "\tMessage: %s\n", message );
-              stdout.printf( "\tMessage Parsed: %s\n", this.parse_message( message, parameters ) );
+              stdout.printf( "\tMessage Parsed: %s\n", this.parse_message( (!)message, parameters ) );
             }
           }
           else if ( mdb == null )
@@ -400,7 +406,7 @@ namespace DMLogger
           }
           else
           {
-            stdout.printf( "%s", this.parse_message( message, parameters ) );
+            stdout.printf( "%s", this.parse_message( (!)message, parameters ) );
           }
           if ( this.type == LOG_ENTRY_ERROR || this.type == LOG_ENTRY_WARNING || this.type == LOG_ENTRY_FATAL )
           {


### PR DESCRIPTION
Messages in message databases are now sorted
log( ) and t( ) methods now "unescape" character combinations like \n and \"
